### PR TITLE
Update for Ember 2.1+

### DIFF
--- a/app/instance-initializers/zeroclipboard.js
+++ b/app/instance-initializers/zeroclipboard.js
@@ -1,10 +1,18 @@
 /* global ZeroClipboard */
 
+function lookupFactory(app, name) {
+  if (app.resolveRegistration) {
+   return app.resolveRegistration(name);
+ }
+
+ return app.container.lookupFactory(name);
+}
+
 export default {
   name: 'zeroclipboard',
 
   initialize: function(application) {
-    var config = application.container.lookupFactory('config:environment')['ember-zeroclipboard'];
+    var config = lookupFactory(application, 'config:environment')['ember-zeroclipboard'];
     if (config) { ZeroClipboard.config(config); }
   }
 };

--- a/app/instance-initializers/zeroclipboard.js
+++ b/app/instance-initializers/zeroclipboard.js
@@ -13,6 +13,6 @@ export default {
 
   initialize: function(application) {
     var config = lookupFactory(application, 'config:environment')['ember-zeroclipboard'];
-    //if (config) { ZeroClipboard.config(config); }
+    if (config) { ZeroClipboard.config(config); }
   }
 };

--- a/app/instance-initializers/zeroclipboard.js
+++ b/app/instance-initializers/zeroclipboard.js
@@ -13,6 +13,6 @@ export default {
 
   initialize: function(application) {
     var config = lookupFactory(application, 'config:environment')['ember-zeroclipboard'];
-    if (config) { ZeroClipboard.config(config); }
+    //if (config) { ZeroClipboard.config(config); }
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,10 +6,12 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import(app.bowerDirectory + '/zeroclipboard/dist/ZeroClipboard.js');
-
-    app.import(app.bowerDirectory + '/zeroclipboard/dist/ZeroClipboard.swf', {
-      destDir: 'assets'
-    });
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/zeroclipboard/dist/ZeroClipboard.js');
+  
+      app.import(app.bowerDirectory + '/zeroclipboard/dist/ZeroClipboard.swf', {
+        destDir: 'assets'
+      });
+    }
   }
 };


### PR DESCRIPTION
This fixes the error `lookupFactory is not a function` in newer Ember versions, while maintaining backwards-compatibility. Tested on my 2.3 application, and works well!
